### PR TITLE
Add support for Symfony 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,32 @@ language: php
 php:
     - 5.3
     - 5.4
+    - 5.5
+    - 5.6
+    - 7.0
+    - 7.1
+    - nightly
 
-before_script:
-    - composer install --dev
+matrix:
+    include:
+        - php: 5.3
+          env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable' SYMFONY_DEPRECATIONS_HELPER=weak
+        - php: 7.1
+          env: DEPENDENCIES=dev SYMFONY_DEPRECATIONS_HELPER=weak
+        # Test against LTS versions
+        - php: 7.0
+          env: SYMFONY_VERSION=2.8.*
+    allow_failures:
+        - php: nightly
+
+sudo: false
+
+cache:
+    directories:
+        - $HOME/.composer/cache/files
+
+before_install:
+    - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
+    - if [ "$DEPENDENCIES" = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
+
+install: composer update --prefer-dist $COMPOSER_FLAGS

--- a/Resources/config/extra.xml
+++ b/Resources/config/extra.xml
@@ -31,14 +31,12 @@
                 These are removed by the DI extension when they should not be activated.
         -->
         <service id="hb_stampie.extra.listener.impersonate" class="%hb_stampie.extra.listener.impersonate.class%">
-            <!-- TODO switch to the kernel.event_subscriber tag when dropping the 2.0 support. -->
-            <tag name="kernel.event_listener" event="stampie.pre_send" method="preSend" />
+            <tag name="kernel.event_subscriber" />
             <argument /><!-- delivery address -->
         </service>
 
         <service id="hb_stampie.listener.message_logger" class="%hb_stampie.listener.message_logger.class%">
-            <!-- TODO switch to the kernel.event_subscriber tag when dropping the 2.0 support. -->
-            <tag name="kernel.event_listener" event="stampie.pre_send" method="preSend" />
+            <tag name="kernel.event_subscriber" />
         </service>
     </services>
 </container>

--- a/Tests/DependencyInjection/HBStampieExtensionTest.php
+++ b/Tests/DependencyInjection/HBStampieExtensionTest.php
@@ -11,7 +11,10 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
  */
 class HBStampieExtensionTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    /** @var HBStampieExtension */
+    private $extension;
+
+    protected function setUp()
     {
         $this->extension = new HBStampieExtension();
     }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "henrikbjorn/stampie-bundle",
     "description": "This bundle provides integration for Stampie Email Library",
-    "keywords": ["symfony2", "stampie", "email"],
+    "keywords": ["symfony", "stampie", "email"],
     "type": "symfony-bundle",
     "license": "MIT",
     "authors": [{
@@ -10,12 +10,13 @@
     }],
     "require": {
         "php"                      : ">=5.3.3",
-        "symfony/framework-bundle" : "~2.0",
-        "symfony/console"          : "~2.0",
-        "henrikbjorn/stampie"      : "~0.6"
+        "symfony/framework-bundle" : "^2.7 || ^3.0",
+        "symfony/console"          : "^2.7 || ^3.0",
+        "henrikbjorn/stampie"      : "~0.11"
     },
     "require-dev": {
-        "stof/stampie-extra": "~0.2@dev"
+        "stof/stampie-extra": "~0.2@dev",
+        "symfony/phpunit-bridge": "^3.2"
     },
     "suggest": {
         "stof/stampie-extra": "to have event-based hooks in the mailer"


### PR DESCRIPTION
This also drops support for Symfony <2.7, which are unmaintained.

I also improved the Travis setup to test against more PHP versions, and the dev versions of deps, and the lowest bound of deps.