### PR TITLE
Run tests using symfony/phpunit-bridge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-    - 5.3
     - 5.4
     - 5.5
     - 5.6
@@ -12,6 +11,9 @@ php:
 matrix:
     include:
         - php: 5.3
+          dist: precise
+        - php: 5.3
+          dist: precise
           env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable' SYMFONY_DEPRECATIONS_HELPER=weak
         - php: 7.1
           env: DEPENDENCIES=dev SYMFONY_DEPRECATIONS_HELPER=weak

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,3 +32,5 @@ before_install:
     - if [ "$DEPENDENCIES" = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
 
 install: composer update --prefer-dist $COMPOSER_FLAGS
+
+script: vendor/bin/simple-phpunit

--- a/Tests/DependencyInjection/HBStampieExtensionTest.php
+++ b/Tests/DependencyInjection/HBStampieExtensionTest.php
@@ -66,7 +66,11 @@ class HBStampieExtensionTest extends TestCase
         $this->assertEquals('hb_stampie.mailer.real', (string) $builder->getAlias('hb_stampie.mailer'));
 
         $this->assertTrue($builder->hasDefinition('hb_stampie.mailer.real'));
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', $builder->getDefinition('hb_stampie.mailer.real'));
+        if (class_exists('Symfony\Component\DependencyInjection\ChildDefinition')) {
+            $this->assertInstanceOf('Symfony\Component\DependencyInjection\ChildDefinition', $builder->getDefinition('hb_stampie.mailer.real'));
+        } else {
+            $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', $builder->getDefinition('hb_stampie.mailer.real'));
+        }
         $this->assertEquals('hb_stampie.mailer.postmark', $builder->getDefinition('hb_stampie.mailer.real')->getParent());
 
         $this->assertEquals(array(

--- a/Tests/DependencyInjection/HBStampieExtensionTest.php
+++ b/Tests/DependencyInjection/HBStampieExtensionTest.php
@@ -3,13 +3,14 @@
 namespace HB\StampieBundle\Tests\DependencyInjection;
 
 use HB\StampieBundle\DependencyInjection\HBStampieExtension;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
 /**
  * @author Henrik Bjornskov <henrik@bjrnskov.dk>
  */
-class HBStampieExtensionTest extends \PHPUnit_Framework_TestCase
+class HBStampieExtensionTest extends TestCase
 {
     /** @var HBStampieExtension */
     private $extension;

--- a/Tests/DependencyInjection/HBStampieExtensionTest.php
+++ b/Tests/DependencyInjection/HBStampieExtensionTest.php
@@ -20,9 +20,12 @@ class HBStampieExtensionTest extends TestCase
         $this->extension = new HBStampieExtension();
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Invalid adapter "DummyAdapter" specified
+     */
     public function testExceptionWhenInvalidAdapterSpecified()
     {
-        $this->setExpectedException('InvalidArgumentException', 'Invalid adapter "DummyAdapter" specified');
         $this->extension->load(array(
             'hb_stampie' => array(
                 'adapter' => 'DummyAdapter',
@@ -32,9 +35,12 @@ class HBStampieExtensionTest extends TestCase
         ), $this->createContainerBuilder());
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Invalid mailer "DummyMailer" specified
+     */
     public function testExceptionWhenInvalidMailerSpecified()
     {
-        $this->setExpectedException('InvalidArgumentException', 'Invalid mailer "DummyMailer" specified');
         $this->extension->load(array(
             'hb_stampie' => array(
                 'adapter' => 'buzz',


### PR DESCRIPTION
PHPUnit version available on travis-ci does not include forward compatibility layer for PHP5.5 and older. Using `simple-phpunit` from `symfony/phpunit-bridge` solve this and help to write tests that work on every PHP version we are testing this bundle against.

This is now ready. This will make a safer base for future developments.