### PR TITLE
Rename the package to stampie/stampie-bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 Integrates [Stampie](https://github.com/Stampie/Stampie) with Symfony.
 
+```bash
+$ composer require stampie/stampie-bundle
+```
+
 ## Usage
 
 Add `Stampie\StampieBundle\StampieBundle()` to your `AppKernel.php` in the `registerBundles` method.

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "henrikbjorn/stampie-bundle",
+    "name": "stampie/stampie-bundle",
     "description": "This bundle provides integration for Stampie Email Library",
     "keywords": ["symfony", "stampie", "email"],
     "type": "symfony-bundle",


### PR DESCRIPTION
After the merge, the new package needs to be registered on Packagist, and the old one marked as abandonned.

Closes #36 